### PR TITLE
updates for successfully importing FHIR json bundles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,12 +48,17 @@ services:
                 OOF_GH_BRANCH: "${OOF_GH_BRANCH:-master}"   # this determines which branch from the above repository we use
                 MAVEN_VERSION: "${MAVEN_VERSION:-3.6.1}"    # this determines the version of the build container
                 OOF_WAR_NAME: "${OOF_WAR_NAME:-omoponfhir2}"
+                DB_TYPE: "${DB_TYPE:--sql}"
         container_name: omop-on-fhir
         depends_on:
             - omop-on-fhir-pg
         environment:
             JDBC_USERNAME: postgres
             JDBC_PASSWORD: example
+            PG_HOST: "omop-on-fhir-pg"
+            PG_PORT: "5432"
+            PG_DATABASE: "omop_db"
+            PG_CURRENTSCHEMA: "public"
             JDBC_URL: jdbc:postgresql://omop-on-fhir-pg:5432/omop_db
             SERVERBASE_URL: http://localhost:8080/omoponfhir2/fhir
             AUTH_BASIC: fhirguy:fhirpass

--- a/docker/omop-on-fhir-pg/omop-init-available/omoponfhir_f_person_ddl.sql
+++ b/docker/omop-on-fhir-pg/omop-init-available/omoponfhir_f_person_ddl.sql
@@ -1,0 +1,16 @@
+create table public.f_person
+(
+	person_id integer not null,
+	family_name character varying(50),
+	given1_name character varying(50),
+	given2_name character varying(50),
+	prefix_name character varying(50),
+	suffix_name character varying(50),
+	preferred_language character varying(50),
+	ssn character varying(50),
+	active integer,
+	contact_point1 character varying(50),
+	contact_point2 character varying(50),
+	contact_point3 character varying(50),
+	maritalstatus character varying(50)
+);

--- a/docker/omop-on-fhir-pg/omop-init-available/omoponfhir_v5.2_f_observation_view_ddl.sql
+++ b/docker/omop-on-fhir-pg/omop-init-available/omoponfhir_v5.2_f_observation_view_ddl.sql
@@ -1,0 +1,50 @@
+CREATE VIEW public.f_observation_view AS
+SELECT
+  measurement.measurement_id AS observation_id,
+  measurement.person_id,
+  measurement.measurement_concept_id AS observation_concept_id,
+  measurement.measurement_date AS observation_date,
+  measurement.measurement_datetime AS observation_datetime,
+  measurement.measurement_type_concept_id AS observation_type_concept_id,
+  measurement.operator_concept_id AS observation_operator_concept_id,
+  measurement.value_as_number,
+  NULL AS value_as_string,
+  measurement.value_as_concept_id,
+  NULL AS qualifier_concept_id,
+  measurement.unit_concept_id,
+  measurement.range_low,
+  measurement.range_high,
+  measurement.provider_id,
+  measurement.visit_occurrence_id,
+  measurement.measurement_source_value AS observation_source_value,
+  measurement.measurement_source_concept_id AS observation_source_concept_id,
+  measurement.unit_source_value,
+  measurement.value_source_value,
+  NULL AS qualifier_source_value
+FROM
+  public.measurement
+UNION ALL
+SELECT
+  (-observation.observation_id) AS observation_id,
+  observation.person_id,
+  observation.observation_concept_id,
+  observation.observation_date,
+  observation.observation_datetime,
+  observation.observation_type_concept_id,
+  NULL AS observation_operator_concept_id,
+  observation.value_as_number,
+  observation.value_as_string,
+  observation.value_as_concept_id,
+  observation.qualifier_concept_id,
+  observation.unit_concept_id,
+  NULL AS range_low,
+  NULL AS range_high,
+  observation.provider_id,
+  observation.visit_occurrence_id,
+  observation.observation_source_value,
+  observation.observation_source_concept_id,
+  observation.unit_source_value,
+  NULL AS value_source_value,
+  observation.qualifier_source_value
+FROM
+  public.observation;

--- a/docker/omop-on-fhir-pg/omop-init-enabled/50_f_person.sql
+++ b/docker/omop-on-fhir-pg/omop-init-enabled/50_f_person.sql
@@ -1,0 +1,1 @@
+../omop-init-available/omoponfhir_f_person_ddl.sql

--- a/docker/omop-on-fhir-pg/omop-init-enabled/60_f_observation.sql
+++ b/docker/omop-on-fhir-pg/omop-init-enabled/60_f_observation.sql
@@ -1,0 +1,1 @@
+../omop-init-available/omoponfhir_v5.2_f_observation_view_ddl.sql

--- a/docker/omop-on-fhir/Dockerfile
+++ b/docker/omop-on-fhir/Dockerfile
@@ -7,6 +7,7 @@ FROM alpine:3 as staging
 ARG OOF_GH_PRJ_URL="https://github.com/omoponfhir"
 ARG OOF_GH_BRANCH="${OOF_GH_BRANCH}"
 ARG FHIR_VERSION="${FHIR_VERSION}"
+ARG DB_TYPE="${DB_TYPE}"
 
 # install git
 RUN apk add --update --no-cache \
@@ -15,8 +16,8 @@ RUN apk add --update --no-cache \
 # 1. clone repo
 # 2. check out specific branch / version
 # 3. init and pull down any / all submodules
-RUN git clone "https://github.com/omoponfhir/omoponfhir-main-${FHIR_VERSION}.git" \
-	&& cd "omoponfhir-main-${FHIR_VERSION}" \
+RUN git clone "https://github.com/omoponfhir/omoponfhir-main-${FHIR_VERSION}${DB_TYPE}.git" \
+	&& cd "omoponfhir-main-${FHIR_VERSION}${DB_TYPE}" \
 	&& git checkout "${OOF_GH_BRANCH}" \
 	&& git submodule init \
 	&& git submodule update --recursive
@@ -29,10 +30,11 @@ RUN apk update --no-cache
 # args!
 ARG FHIR_VERSION="${FHIR_VERSION}"
 ARG WORKDIR_PATH="/usr/src/app"
+ARG DB_TYPE="${DB_TYPE}"
 
 # copy in souce code from staging container
 # note: i do this as mv that comes with busybox-utils tries to be "helpful" and just gets in my way.
-COPY --from=staging "/omoponfhir-main-${FHIR_VERSION}" "${WORKDIR_PATH}"
+COPY --from=staging "/omoponfhir-main-${FHIR_VERSION}${DB_TYPE}" "${WORKDIR_PATH}"
 
 # set working directory for rest of stage
 WORKDIR "${WORKDIR_PATH}"


### PR DESCRIPTION
notable changes:

1. allows you to select -sql or -jpabase (although we recommend only using the -sql version) of the code
2. adds additional args required for OMOPonFHIR to work properly (namely the PG_HOST, etc)
3. add f_person and f_observation tables. 
